### PR TITLE
Add power switch (address 0)

### DIFF
--- a/custom_components/heru/const.py
+++ b/custom_components/heru/const.py
@@ -364,6 +364,13 @@ HERU_BUTTONS = [
 
 HERU_SWITCHES = [
     {
+        "name": "Power",
+        "modbus_address": "0x00001",
+        "address": 0,
+        "icon": ICON_SWITCH,
+        "register_type": COIL,
+    },
+    {
         "name": "Overpressure mode",
         "modbus_address": "0x00002",
         "address": 1,


### PR DESCRIPTION
This is based on the following stanza from my existing custom modbus integration:

```
      switches:
        - name: ftx_power
          slave: 1
          address: 0
          write_type: coil
          scan_interval: 5
          verify:
```

The effect of calling this is like using the "power on/off" button on the Heru remote.

This is the only omission I can find, now that I am trying to move away from my custom integration to this.