### PR TITLE
Fix pymodbus conflict as of 2025.1.0 and deprecated alias which will …

### DIFF
--- a/custom_components/heru/__init__.py
+++ b/custom_components/heru/__init__.py
@@ -5,7 +5,8 @@ from custom_components.heru.helpers.general import get_parameter
 from custom_components.heru.heru_coordinator import HeruCoordinator
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import Config, HomeAssistant
+from homeassistant.core import HomeAssistant
+from homeassistant.core_config import Config  # Updated import
 
 from pymodbus.client import (
     AsyncModbusTcpClient,
@@ -33,7 +34,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     _LOGGER.debug("async_setup_entry")
     host_name = get_parameter(entry, CONF_HOST_NAME)
     host_port = int(get_parameter(entry, CONF_HOST_PORT))
-    client = AsyncModbusTcpClient(host_name, host_port)
+    client = AsyncModbusTcpClient(host=host_name, port=host_port)  # Updated instantiation
 
     if DOMAIN not in hass.data:
         hass.data[DOMAIN] = {}

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,2 +1,2 @@
-homeassistant==2024.4.3
-pymodbus==3.6.8
+homeassistant==2025.1.0
+pymodbus==3.7.4


### PR DESCRIPTION
Changes to fix the pymodbus error that occured in HA Core 2025.1.0 and the coming deprecated alias which will be removed in HA Core 2025.11.

https://github.com/toringer/home-assistant-heru/issues/49
https://github.com/toringer/home-assistant-heru/issues/50
